### PR TITLE
Refactor/combine from_bytes and from_stream

### DIFF
--- a/hydration/__init__.py
+++ b/hydration/__init__.py
@@ -10,7 +10,8 @@ from .fields import FieldPlaceholder
 
 pre_bytes_hook = Struct.pre_bytes_hook
 post_bytes_hook = Struct.post_bytes_hook
-from_bytes_hook = Struct.from_bytes_hook
+from_bytes_hook = Struct.pre_deserialization_hook
+pre_deserialization_hook = Struct.pre_deserialization_hook
 
 LittleEndian = Endianness.LittleEndian
 BigEndian = Endianness.BigEndian
@@ -25,5 +26,5 @@ __all__ = ['Struct', 'Endianness',
            'Array', 'Vector', 'IPv4', 'FieldPlaceholder',
            'ExactValueValidator', 'RangeValidator', 'FunctionValidator', 'SetValidator',
            'Message', 'InclusiveLengthField', 'ExclusiveLengthField', 'OpcodeField',
-           'pre_bytes_hook', 'post_bytes_hook', 'from_bytes_hook',
+           'pre_bytes_hook', 'post_bytes_hook', 'pre_deserialization_hook', 'from_bytes_hook',
            'LittleEndian', 'BigEndian', 'NativeEndian', 'NetworkEndian']

--- a/hydration/__init__.py
+++ b/hydration/__init__.py
@@ -8,10 +8,13 @@ from .validators import ExactValueValidator, RangeValidator, FunctionValidator, 
 from .message import Message, InclusiveLengthField, ExclusiveLengthField, OpcodeField
 from .fields import FieldPlaceholder
 
-pre_bytes_hook = Struct.pre_bytes_hook
-post_bytes_hook = Struct.post_bytes_hook
-from_bytes_hook = Struct.pre_deserialization_hook
-pre_deserialization_hook = Struct.pre_deserialization_hook
+pre_serialization_hook = Struct.pre_serialization_hook
+post_serialization_hook = Struct.post_serialization_hook
+deserialization_hook = Struct.deserialization_hook
+
+pre_bytes_hook = Struct.pre_serialization_hook
+post_bytes_hook = Struct.post_serialization_hook
+from_bytes_hook = Struct.deserialization_hook
 
 LittleEndian = Endianness.LittleEndian
 BigEndian = Endianness.BigEndian
@@ -26,5 +29,6 @@ __all__ = ['Struct', 'Endianness',
            'Array', 'Vector', 'IPv4', 'FieldPlaceholder',
            'ExactValueValidator', 'RangeValidator', 'FunctionValidator', 'SetValidator',
            'Message', 'InclusiveLengthField', 'ExclusiveLengthField', 'OpcodeField',
-           'pre_bytes_hook', 'post_bytes_hook', 'pre_deserialization_hook', 'from_bytes_hook',
+           'pre_serialization_hook', 'post_serialization_hook', 'deserialization_hook',
+           'from_bytes_hook', 'pre_bytes_hook', 'post_bytes_hook',
            'LittleEndian', 'BigEndian', 'NativeEndian', 'NetworkEndian']

--- a/hydration/base.py
+++ b/hydration/base.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 from pyhooks import Hook, precall_register, postcall_register
 from typing import Callable, List, Iterable, Optional
 
-from .helpers import as_obj, assert_no_property_override, as_type
+from .helpers import as_obj, assert_no_property_override, as_type, as_stream
 from .scalars import Scalar, Enum
 from .fields import Field, VLA, FieldPlaceholder
 from .endianness import Endianness
@@ -219,32 +219,7 @@ class Struct(metaclass=StructMeta):
         :param args: Arguments for the __init__ of the Struct, if there's any
         :return The deserialized struct
         """
-
-        obj = cls(*args)
-
-        for field_name in obj._field_names:
-
-            # Get field for current field name
-            field = getattr(obj, field_name)
-
-            obj.invoke_from_bytes_hooks(field)
-
-            # Bytes hooks can change the field object, so get it again by name
-            field = getattr(obj, field_name)
-
-            if isinstance(field, VLA):
-                field.length = int(getattr(obj, field.length_field_name))
-                field.from_bytes(data)
-                data = data[len(bytes(field)):]
-            else:
-                split_index = field.size
-
-                field_data, data = data[:split_index], data[split_index:]
-                field.value = field.from_bytes(field_data).value
-                with suppress(AttributeError):
-                    field.validator.validate(field.value)
-
-        return obj
+        return cls.from_stream(as_stream(data), *args)
 
     @classmethod
     def from_stream(cls, read_func: Callable[[int], bytes], *args):
@@ -260,19 +235,21 @@ class Struct(metaclass=StructMeta):
 
         obj = cls(*args)
 
-        for field in obj._fields:
+        for field_name in obj._field_names:
+
+            # Get field for current field name
+            field = getattr(obj, field_name)
 
             obj.invoke_from_bytes_hooks(field)
 
+            # Bytes hooks can change the field object, so get it again by name
+            field = getattr(obj, field_name)
+
             if isinstance(field, VLA):
                 field.length = int(getattr(obj, field.length_field_name))
-                data = read_func(field.length)
-                field.from_bytes(data)
+                field.from_stream(read_func)
             else:
-                read_size = field.size
-
-                data = read_func(read_size)
-                field.value = field.from_bytes(data).value
+                field.value = field.from_stream(read_func).value
                 with suppress(AttributeError):
                     field.validator.validate(field.value)
 

--- a/hydration/fields.py
+++ b/hydration/fields.py
@@ -51,6 +51,10 @@ class Field(ABC):
     def from_bytes(self, data: bytes):
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def from_stream(self, reader):
+        raise NotImplementedError
+
     def __eq__(self, other):
         if isinstance(other, Field):
             return self.value == other.value and len(self) == len(other)
@@ -117,4 +121,7 @@ class FieldPlaceholder(Field):
         raise AttributeError('Placeholders cannot be serialized')
 
     def from_bytes(self, data: bytes):
+        raise AttributeError('Placeholders cannot be deserialized')
+
+    def from_stream(self, reader):
         raise AttributeError('Placeholders cannot be deserialized')

--- a/hydration/fields.py
+++ b/hydration/fields.py
@@ -1,5 +1,6 @@
 import abc
 from abc import ABC
+from hydration.helpers import as_stream
 from typing import Union, Callable
 
 from .validators import ValidatorABC
@@ -47,9 +48,8 @@ class Field(ABC):
     def __bytes__(self) -> bytes:
         raise NotImplementedError
 
-    @abc.abstractmethod
     def from_bytes(self, data: bytes):
-        raise NotImplementedError
+        return self.from_stream(as_stream(data))
 
     @abc.abstractmethod
     def from_stream(self, read_func: Callable[[int], bytes]):
@@ -119,9 +119,6 @@ class FieldPlaceholder(Field):
 
     def __bytes__(self) -> bytes:
         raise AttributeError('Placeholders cannot be serialized')
-
-    def from_bytes(self, data: bytes):
-        raise AttributeError('Placeholders cannot be deserialized')
 
     def from_stream(self, read_func: Callable[[int], bytes]):
         raise AttributeError('Placeholders cannot be deserialized')

--- a/hydration/fields.py
+++ b/hydration/fields.py
@@ -1,6 +1,6 @@
 import abc
 from abc import ABC
-from typing import Union
+from typing import Union, Callable
 
 from .validators import ValidatorABC
 
@@ -52,7 +52,7 @@ class Field(ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def from_stream(self, reader):
+    def from_stream(self, read_func: Callable[[int], bytes]):
         raise NotImplementedError
 
     def __eq__(self, other):
@@ -123,5 +123,5 @@ class FieldPlaceholder(Field):
     def from_bytes(self, data: bytes):
         raise AttributeError('Placeholders cannot be deserialized')
 
-    def from_stream(self, reader):
+    def from_stream(self, read_func: Callable[[int], bytes]):
         raise AttributeError('Placeholders cannot be deserialized')

--- a/hydration/helpers.py
+++ b/hydration/helpers.py
@@ -20,3 +20,14 @@ def assert_no_property_override(obj, base_class):
             if (isinstance(getattr(base_class, attr_name), property) and
                     not isinstance(getattr(type(obj), attr_name), property)):
                 raise NameError(f"'{attr_name}' is an invalid name for an attribute in a sequenced or nested struct")
+
+def as_stream(data: bytes):
+    class Reader:
+        def __init__(self, content: bytes):
+            self._data = content
+
+        def read(self, size=0):
+            user_data, self._data = self._data[:size], self._data[size:]
+            return user_data
+    
+    return Reader(data).read

--- a/hydration/message.py
+++ b/hydration/message.py
@@ -182,6 +182,9 @@ class MetaField(Field, ABC):
 
     def __bytes__(self) -> bytes:
         return bytes(self.data_field)
+    
+    def from_stream(self, reader):
+        return self.data_field.from_stream(reader)
 
     def from_bytes(self, data: bytes):
         return self.data_field.from_bytes(data)

--- a/hydration/message.py
+++ b/hydration/message.py
@@ -1,7 +1,7 @@
 import inspect
 from abc import ABC, abstractmethod
 from contextlib import suppress
-from typing import List, Union, Type, Mapping
+from typing import List, Union, Type, Mapping, Callable
 
 from hydration.helpers import as_obj
 from .base import Struct
@@ -183,8 +183,8 @@ class MetaField(Field, ABC):
     def __bytes__(self) -> bytes:
         return bytes(self.data_field)
     
-    def from_stream(self, reader):
-        return self.data_field.from_stream(reader)
+    def from_stream(self, read_func: Callable[[int], bytes]):
+        return self.data_field.from_stream(read_func)
 
     def from_bytes(self, data: bytes):
         return self.data_field.from_bytes(data)

--- a/hydration/message.py
+++ b/hydration/message.py
@@ -186,9 +186,6 @@ class MetaField(Field, ABC):
     def from_stream(self, read_func: Callable[[int], bytes]):
         return self.data_field.from_stream(read_func)
 
-    def from_bytes(self, data: bytes):
-        return self.data_field.from_bytes(data)
-
     @abstractmethod
     def update(self, message: Message, struct: Struct, struct_index: int):
         raise NotImplementedError

--- a/hydration/scalars.py
+++ b/hydration/scalars.py
@@ -125,9 +125,9 @@ class Scalar(Field, Real):
     def __get_format_string(self):
         return '{}{}'.format(self.endianness_format, self.scalar_format)
 
-    def from_stream(self, reader):
+    def from_stream(self, read_func: Callable[[int], bytes]):
         format_string = self.__get_format_string()
-        data = reader(struct.calcsize(format_string))
+        data = read_func(struct.calcsize(format_string))
         return self.from_bytes(data)
 
     def from_bytes(self, data: bytes):
@@ -320,8 +320,8 @@ class Enum(Field):
         except ValueError as e:
             raise ValueError(f'Error serializing {repr(self)}:\n{str(e)}')
     
-    def from_stream(self, reader):
-        self.type.from_stream(reader)
+    def from_stream(self, read_func: Callable[[int], bytes]):
+        self.type.from_stream(read_func)
         self.value = self.type.value
         return self
 

--- a/hydration/scalars.py
+++ b/hydration/scalars.py
@@ -122,16 +122,9 @@ class Scalar(Field, Real):
     def __float__(self) -> float:
         return float(self.value)
 
-    def __get_format_string(self):
-        return '{}{}'.format(self.endianness_format, self.scalar_format)
-
     def from_stream(self, read_func: Callable[[int], bytes]):
-        format_string = self.__get_format_string()
+        format_string = '{}{}'.format(self.endianness_format, self.scalar_format)
         data = read_func(struct.calcsize(format_string))
-        return self.from_bytes(data)
-
-    def from_bytes(self, data: bytes):
-        format_string = self.__get_format_string()
         # noinspection PyAttributeOutsideInit
         self.value = struct.unpack(format_string, data)[0]
         return self
@@ -322,11 +315,6 @@ class Enum(Field):
     
     def from_stream(self, read_func: Callable[[int], bytes]):
         self.type.from_stream(read_func)
-        self.value = self.type.value
-        return self
-
-    def from_bytes(self, data: bytes):
-        self.type.from_bytes(data)
         self.value = self.type.value
         return self
 

--- a/hydration/vectors.py
+++ b/hydration/vectors.py
@@ -153,6 +153,9 @@ class Array(_Sequence):
     def size(self):
         return len(self) * len(self.type)
 
+    def from_stream(self, reader):
+        return self.from_bytes(reader(self.size))
+
 
 class Vector(_Sequence, VLA):
 
@@ -171,6 +174,17 @@ class Vector(_Sequence, VLA):
 
         # This assumes that the Struct will update the length field's value
         self.length = len(value)
+
+    def from_stream(self, reader):
+        if isinstance(self.type, Field):
+            return super().from_bytes(reader(len(self) * len(self.type)))
+        else:
+            val = []
+            for _ in range(len(self)):
+                next_obj = self.type.from_stream(reader)
+                val.append(next_obj)
+            self.value = val
+            return self
 
     def from_bytes(self, data: bytes):
         if isinstance(self.type, Field):

--- a/hydration/vectors.py
+++ b/hydration/vectors.py
@@ -1,7 +1,7 @@
 import copy
 from abc import ABC
 from collections import UserList
-from typing import Sequence, Optional, Any, Union, Iterable
+from typing import Sequence, Optional, Any, Union, Iterable, Callable
 from itertools import islice
 
 from .base import Struct
@@ -153,8 +153,8 @@ class Array(_Sequence):
     def size(self):
         return len(self) * len(self.type)
 
-    def from_stream(self, reader):
-        return self.from_bytes(reader(self.size))
+    def from_stream(self, read_func: Callable[[int], bytes]):
+        return self.from_bytes(read_func(self.size))
 
 
 class Vector(_Sequence, VLA):
@@ -175,13 +175,13 @@ class Vector(_Sequence, VLA):
         # This assumes that the Struct will update the length field's value
         self.length = len(value)
 
-    def from_stream(self, reader):
+    def from_stream(self, read_func: Callable[[int], bytes]):
         if isinstance(self.type, Field):
-            return super().from_bytes(reader(len(self) * len(self.type)))
+            return super().from_bytes(read_func(len(self) * len(self.type)))
         else:
             val = []
             for _ in range(len(self)):
-                next_obj = self.type.from_stream(reader)
+                next_obj = self.type.from_stream(read_func)
                 val.append(next_obj)
             self.value = val
             return self

--- a/hydration/vectors.py
+++ b/hydration/vectors.py
@@ -186,18 +186,6 @@ class Vector(_Sequence, VLA):
             self.value = val
             return self
 
-    def from_bytes(self, data: bytes):
-        if isinstance(self.type, Field):
-            return super().from_bytes(data[:len(self) * len(self.type)])
-        else:
-            val = []
-            for _ in range(len(self)):
-                next_obj = self.type.from_bytes(data)
-                val.append(next_obj)
-                data = data[len(bytes(next_obj)):]
-            self.value = val
-            return self
-
     def __len__(self) -> int:
         return VLA.__len__(self)
 


### PR DESCRIPTION
Fixes #35 

- Combined `from_stream` and `from_bytes` by creating a `as_stream` utility.
- Fixed a bug in `from_stream` where bytes hooks can change the field object (with code which already existed in `from_bytes`).
- Renamed `from_bytes_hook` to `pre_deserialization_hook` but kept the old name there for backward-compatibility.